### PR TITLE
Move Facebook App Id into Config Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ public/bundle.js
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules/
 bower_components/
+
+# client config file
+client/config.jsx

--- a/client/config.example.jsx
+++ b/client/config.example.jsx
@@ -1,0 +1,5 @@
+let Config = {
+  FACEBOOK_APP_ID: '0000000000000000'
+};
+
+export default Config;

--- a/client/config.example.jsx
+++ b/client/config.example.jsx
@@ -1,3 +1,6 @@
+// make your own copy of this file with the name `config.jsx`
+// and then update the variables for your local dev environment
+
 let Config = {
   FACEBOOK_APP_ID: '0000000000000000'
 };

--- a/client/config.jsx
+++ b/client/config.jsx
@@ -1,0 +1,5 @@
+let Config = {
+  FACEBOOK_APP_ID: '1140621792677350'
+};
+
+export default Config;

--- a/client/config.jsx
+++ b/client/config.jsx
@@ -1,5 +1,0 @@
-let Config = {
-  FACEBOOK_APP_ID: '1140621792677350'
-};
-
-export default Config;

--- a/client/fbook-button.jsx
+++ b/client/fbook-button.jsx
@@ -1,25 +1,26 @@
-import React from 'react'; 
-import $ from 'jquery'; 
+import Config from './config';
+import React from 'react';
+import $ from 'jquery';
 import { hashHistory } from 'react-router';
 
 
 class FacebookButton extends React.Component {
   constructor (props) {
-    super(props); 
- 
+    super(props);
+
     this.state = {
       authenticated: false,
-      userMessage: "", 
+      userMessage: "",
     }
 
     this.handleClick = this.handleClick.bind(this)
   }
 
   componentDidMount () {
-    var self = this; 
+    var self = this;
     window.fbAsyncInit = function() {
       FB.init({
-        appId      : '1171407722880061',
+        appId      : Config.FACEBOOK_APP_ID,
         xfbml      : true,
         version    : 'v2.6'
       });
@@ -36,29 +37,29 @@ class FacebookButton extends React.Component {
   }
 
   checkLoginState () {
-    var self = this;  
+    var self = this;
     FB.getLoginStatus(function(response) {
       if (response.status === 'connected') {
-        self.setState({authenticated: true});     
+        self.setState({authenticated: true});
       } else {
         FB.login(function(response) {
           console.log(response, 'outside api call')
-          var access_token = response.authResponse.accessToken; 
+          var access_token = response.authResponse.accessToken;
           if (response.authResponse) {
             FB.api('/me', function(response) {
               self.setState({authenticated: true});
               console.log('in api call',response)
               $.post('/signin', {name: response.name, userId: response.id, access_token: access_token}).done(function(data) {
-                console.log('success'); 
-                window.fbId = response.id; 
-                window.access_token = access_token; 
-                hashHistory.push('dashboard'); 
+                console.log('success');
+                window.fbId = response.id;
+                window.access_token = access_token;
+                hashHistory.push('dashboard');
               }).fail(function(err) {
-                console.log(err, 'error in checkLoginState'); 
-              }); 
-            }); 
+                console.log(err, 'error in checkLoginState');
+              });
+            });
           } else {
-            console.log('user did not authenticate'); 
+            console.log('user did not authenticate');
           }
         }, {scope: 'public_profile,user_photos'})
       }
@@ -66,20 +67,20 @@ class FacebookButton extends React.Component {
   }
 
   logout () {
-    var self = this; 
-    console.log('is this working?'); 
+    var self = this;
+    console.log('is this working?');
     FB.logout(function(response) {
-      self.setState({authenticated: false}); 
-      hashHistory.push('/login'); 
+      self.setState({authenticated: false});
+      hashHistory.push('/login');
     })
   }
 
   handleClick (e) {
-    e.preventDefault(); 
+    e.preventDefault();
     if (this.state.authenticated) {
-      this.logout(); 
+      this.logout();
     } else {
-      this.checkLoginState();  
+      this.checkLoginState();
     }
   }
 
@@ -89,8 +90,8 @@ class FacebookButton extends React.Component {
       <div>
         <button className='facebook-login' onClick={this.handleClick}>Log in with Facebook</button>
       </div>
-    ); 
+    );
   }
 }
 
-export default FacebookButton; 
+export default FacebookButton;


### PR DESCRIPTION
I've moved the Facebook App Id into the Config module. If you need it, just do a `import Config from './config';` and then you can refer to it by `Config.FACEBOOK_APP_ID`. Other variables can be put in here in the same way if we find the need.

Make sure to make a copy of the file and name it `config.jsx` and put your App Id in there.
